### PR TITLE
Added methods to reset expectations/rejects and stubs

### DIFF
--- a/Sources/InstantMock/Interceptors/Helpers/CallInterceptorStorage.swift
+++ b/Sources/InstantMock/Interceptors/Helpers/CallInterceptorStorage.swift
@@ -45,4 +45,8 @@ class CallInterceptorStorage<T: CallInterceptor> {
         }
     }
 
+    /** Invalidates repository */
+    func removeAll() {
+        self.repository.removeAll()
+    }
 }

--- a/Sources/InstantMock/Mock.swift
+++ b/Sources/InstantMock/Mock.swift
@@ -91,6 +91,19 @@ open class Mock {
         self.expectationFactory = expectationFactory
     }
 
+    
+    // MARK: Methods
+    /** Resets all expectations and rejects */
+    public func resetExpectations() {
+        self.expectationBeingRegistered = nil
+        self.expectationStorage.removeAll()
+    }
+    
+    /** Resets all stubs */
+    public func resetStubs() {
+        self.stubBeingRegistered = nil
+        self.stubStorage.removeAll()
+    }
 }
 
 

--- a/Tests/InstantMockTests/Integration Tests/BasicMockTests.swift
+++ b/Tests/InstantMockTests/Integration Tests/BasicMockTests.swift
@@ -61,6 +61,8 @@ class BasicMockTests: XCTestCase {
         ("testExpectProperty_value", testExpectProperty_value),
         ("testExpectProperty_any", testExpectProperty_any),
         ("testExpectProperty_value_setter_getter", testExpectProperty_value_setter_getter),
+        ("testResetExpectations", testResetExpectations),
+        ("testResetStubs", testResetStubs),
     ]
 
 
@@ -228,4 +230,17 @@ class BasicMockTests: XCTestCase {
         XCTAssertTrue(self.assertionMock.succeeded)
     }
 
+    func testResetExpectations() {
+        mock.reject().call(mock.basic(arg1: Arg.any(), arg2: Arg.any()))
+        mock.resetExpectations()
+        _ = mock.basic(arg1: "", arg2: 0)
+        mock.verify()
+    }
+    
+    func testResetStubs() {
+        mock.stub().call(mock.basic(arg1: Arg.any(), arg2: Arg.any())).andReturn("string")
+        mock.resetStubs()
+        let ret = mock.basic(arg1: "", arg2: 2)
+        XCTAssertNotEqual(ret, "string")
+    }
 }

--- a/Tests/InstantMockTests/Unit Tests/Interceptors/CallInterceptorStorageTests.swift
+++ b/Tests/InstantMockTests/Unit Tests/Interceptors/CallInterceptorStorageTests.swift
@@ -27,6 +27,7 @@ class CallInterceptorStorageTests: XCTestCase {
         ("testInterceptors", testInterceptors),
         ("testRegisterInterceptors", testRegisterInterceptors),
         ("testAll", testAll),
+        ("testRemoveAll", testRemoveAll),
     ]
 
 
@@ -70,5 +71,13 @@ class CallInterceptorStorageTests: XCTestCase {
         XCTAssertTrue(all.contains(where: { $0 === stub2} ))
         XCTAssertTrue(all.contains(where: { $0 === stub3} ))
     }
-
+    
+    func testRemoveAll() {
+        self.repository.store(interceptor: stub, for: "someFunction")
+        let stub2 = Stub()
+        self.repository.store(interceptor: stub2, for: "someFunction")
+        XCTAssertEqual(self.repository.all().count, 2)
+        self.repository.removeAll()
+        XCTAssertEqual(self.repository.all().count, 0)
+    }
 }


### PR DESCRIPTION
Sometimes there is a need to check that under some conditions call is not being made at all, while changing them call is made so need a way to reset rejects