### PR TITLE
Add support for Float, Int64, UInt64

### DIFF
--- a/InstantMock.xcodeproj/project.pbxproj
+++ b/InstantMock.xcodeproj/project.pbxproj
@@ -301,6 +301,12 @@
 		43E6EFD71EE74F4C00FFC9E0 /* SetMockUsableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E6EE891EE73F7D00FFC9E0 /* SetMockUsableTests.swift */; };
 		43E6EFD81EE74F4C00FFC9E0 /* StringMockUsableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E6EE8A1EE73F7D00FFC9E0 /* StringMockUsableTests.swift */; };
 		43E6EFD91EE74F5100FFC9E0 /* VerifierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43E6EE931EE73FA100FFC9E0 /* VerifierTests.swift */; };
+		517CDAE7244EF62F00952FF5 /* Float+MockUsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517CDAE6244EF62F00952FF5 /* Float+MockUsable.swift */; };
+		517CDAE8244EF62F00952FF5 /* Float+MockUsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517CDAE6244EF62F00952FF5 /* Float+MockUsable.swift */; };
+		517CDAE9244EF62F00952FF5 /* Float+MockUsable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517CDAE6244EF62F00952FF5 /* Float+MockUsable.swift */; };
+		517CDAEE244EF66300952FF5 /* FloatMockUsableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517CDAEA244EF65A00952FF5 /* FloatMockUsableTests.swift */; };
+		517CDAEF244EF66300952FF5 /* FloatMockUsableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517CDAEA244EF65A00952FF5 /* FloatMockUsableTests.swift */; };
+		517CDAF0244EF66400952FF5 /* FloatMockUsableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 517CDAEA244EF65A00952FF5 /* FloatMockUsableTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -433,6 +439,8 @@
 		43E6EED31EE749B700FFC9E0 /* InstantMockTests macOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "InstantMockTests macOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		43E6EF701EE74E8400FFC9E0 /* InstantMock.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = InstantMock.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		43E6EF781EE74E8400FFC9E0 /* InstantMockTests tvOS.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "InstantMockTests tvOS.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		517CDAE6244EF62F00952FF5 /* Float+MockUsable.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Float+MockUsable.swift"; sourceTree = "<group>"; };
+		517CDAEA244EF65A00952FF5 /* FloatMockUsableTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FloatMockUsableTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -694,6 +702,7 @@
 				43E6EE191EE73E9F00FFC9E0 /* Bool+MockUsable.swift */,
 				43E6EE1A1EE73E9F00FFC9E0 /* Dictionary+MockUsable.swift */,
 				43E6EE1B1EE73E9F00FFC9E0 /* Double+MockUsable.swift */,
+				517CDAE6244EF62F00952FF5 /* Float+MockUsable.swift */,
 				43E6EE1C1EE73E9F00FFC9E0 /* Int+MockUsable.swift */,
 				43E6EE1D1EE73E9F00FFC9E0 /* MockUsable.swift */,
 				43E6EE1E1EE73E9F00FFC9E0 /* Set+MockUsable.swift */,
@@ -837,6 +846,7 @@
 				43E6EE851EE73F7D00FFC9E0 /* BoolMockUsableTests.swift */,
 				43E6EE861EE73F7D00FFC9E0 /* DictionaryMockUsableTests.swift */,
 				43E6EE871EE73F7D00FFC9E0 /* DoubleMockUsableTests.swift */,
+				517CDAEA244EF65A00952FF5 /* FloatMockUsableTests.swift */,
 				43E6EE881EE73F7D00FFC9E0 /* IntMockUsableTests.swift */,
 				43E6EE891EE73F7D00FFC9E0 /* SetMockUsableTests.swift */,
 				43E6EE8A1EE73F7D00FFC9E0 /* StringMockUsableTests.swift */,
@@ -1145,6 +1155,7 @@
 				43E6EE011EE73E3000FFC9E0 /* ArgumentsMatcher.swift in Sources */,
 				43E6EDF01EE73DE500FFC9E0 /* ArgumentVerify.swift in Sources */,
 				43E6EDF81EE73E1E00FFC9E0 /* ArgumentCaptorValues.swift in Sources */,
+				517CDAE7244EF62F00952FF5 /* Float+MockUsable.swift in Sources */,
 				43E6EE221EE73E9F00FFC9E0 /* Dictionary+MockUsable.swift in Sources */,
 				43E6EDF71EE73E1E00FFC9E0 /* ArgumentCaptor.swift in Sources */,
 				43E6EDF21EE73DE500FFC9E0 /* ArgumentVerifyOptional.swift in Sources */,
@@ -1173,6 +1184,7 @@
 				43400AB01F23DCFE00F892EC /* ArgumentClosureCaptorTests+NoArg.swift in Sources */,
 				431C4CA01F2372010081CEE4 /* ArgumentClosureCaptorTests+OneArg.swift in Sources */,
 				43E6EEA41EE7410600FFC9E0 /* ClosureMockTests.swift in Sources */,
+				517CDAF0244EF66400952FF5 /* FloatMockUsableTests.swift in Sources */,
 				43E6EEBC1EE7412D00FFC9E0 /* StubTests.swift in Sources */,
 				431C4CAA1F2372570081CEE4 /* ArgumentClosureCaptor+TwoArgs.swift in Sources */,
 				43E6EEA01EE7410200FFC9E0 /* ExpectationFactoryMock.swift in Sources */,
@@ -1255,6 +1267,7 @@
 				43E6EEF91EE74A4000FFC9E0 /* ArgumentFactory.swift in Sources */,
 				43E6EF121EE74A6200FFC9E0 /* Mock.swift in Sources */,
 				431C4CA31F2372090081CEE4 /* ArgumentClosureCaptor+OneArg.swift in Sources */,
+				517CDAE8244EF62F00952FF5 /* Float+MockUsable.swift in Sources */,
 				43E6EF111EE74A6200FFC9E0 /* Verifier.swift in Sources */,
 				43E6EEF61EE74A3B00FFC9E0 /* ArgumentCaptor.swift in Sources */,
 				43E6EEFD1EE74A4700FFC9E0 /* DefaultClosureHandler.swift in Sources */,
@@ -1283,6 +1296,7 @@
 				43400AB11F23DCFF00F892EC /* ArgumentClosureCaptorTests+NoArg.swift in Sources */,
 				431C4CA11F2372020081CEE4 /* ArgumentClosureCaptorTests+OneArg.swift in Sources */,
 				43E6EF171EE74A7900FFC9E0 /* ClosureMockTests.swift in Sources */,
+				517CDAEF244EF66300952FF5 /* FloatMockUsableTests.swift in Sources */,
 				43E6EF2F1EE74A9D00FFC9E0 /* StubTests.swift in Sources */,
 				431C4CAB1F2372570081CEE4 /* ArgumentClosureCaptor+TwoArgs.swift in Sources */,
 				43E6EEEB1EE74A1500FFC9E0 /* ExpectationFactoryMock.swift in Sources */,
@@ -1365,6 +1379,7 @@
 				43E6EF931EE74F0100FFC9E0 /* ArgumentFactory.swift in Sources */,
 				43E6EFA91EE74F1A00FFC9E0 /* Mock.swift in Sources */,
 				431C4CA41F2372090081CEE4 /* ArgumentClosureCaptor+OneArg.swift in Sources */,
+				517CDAE9244EF62F00952FF5 /* Float+MockUsable.swift in Sources */,
 				43E6EFA81EE74F1A00FFC9E0 /* Verifier.swift in Sources */,
 				43E6EF901EE74EFC00FFC9E0 /* ArgumentCaptor.swift in Sources */,
 				43E6EF971EE74F0700FFC9E0 /* DefaultClosureHandler.swift in Sources */,
@@ -1393,6 +1408,7 @@
 				43400AB21F23DCFF00F892EC /* ArgumentClosureCaptorTests+NoArg.swift in Sources */,
 				431C4CA21F2372020081CEE4 /* ArgumentClosureCaptorTests+OneArg.swift in Sources */,
 				43E6EFCB1EE74F4100FFC9E0 /* DefaultClosureHandlerTests.swift in Sources */,
+				517CDAEE244EF66300952FF5 /* FloatMockUsableTests.swift in Sources */,
 				43E6EFB71EE74F2A00FFC9E0 /* BasicMockTests.swift in Sources */,
 				431C4CAD1F2372580081CEE4 /* ArgumentClosureCaptor+TwoArgs.swift in Sources */,
 				43E6EFC01EE74F3300FFC9E0 /* ArgumentCaptureTests.swift in Sources */,

--- a/README.md
+++ b/README.md
@@ -341,7 +341,9 @@ Indeed, adding this extension to both a parent and a subclass would create build
 
 For now, the following types are `MockUsable`:
 * Bool
-* Int
+* Int, Int64
+* UInt, UInt64
+* Float
 * Double
 * String
 * Set

--- a/Sources/InstantMock/MockUsable/Float+MockUsable.swift
+++ b/Sources/InstantMock/MockUsable/Float+MockUsable.swift
@@ -2,7 +2,7 @@
 //  Float+MockUsable.swift
 //  InstantMock
 //
-//  Created by Patrick on 06/05/2017.
+//  Created by Arnaud Barisain-Monrose on 21/04/2020.
 //  Copyright © 2017 pirishd. All rights reserved.
 //
 

--- a/Sources/InstantMock/MockUsable/Float+MockUsable.swift
+++ b/Sources/InstantMock/MockUsable/Float+MockUsable.swift
@@ -1,0 +1,24 @@
+//
+//  Float+MockUsable.swift
+//  InstantMock
+//
+//  Created by Patrick on 06/05/2017.
+//  Copyright © 2017 pirishd. All rights reserved.
+//
+
+
+/** Extension for making `Float` easily usage in mocks */
+extension Float: MockUsable {
+
+    public static let any = 42.0 as Float
+
+    public static var anyValue: MockUsable {
+        return Float.any
+    }
+
+    public func equal(to value: MockUsable?) -> Bool {
+        guard let doubleValue = value as? Float else { return false }
+        return self == doubleValue
+    }
+
+}

--- a/Sources/InstantMock/MockUsable/Int+MockUsable.swift
+++ b/Sources/InstantMock/MockUsable/Int+MockUsable.swift
@@ -10,10 +10,6 @@
 /** Extension for making `Int` easily usage in mocks */
 extension FixedWidthInteger where Self: MockUsable {
 
-    public static var anyValue: MockUsable {
-        return Int.any
-    }
-
     public func equal(to value: MockUsable?) -> Bool {
         guard let intValue = value as? Self else { return false }
         return self == intValue
@@ -21,7 +17,31 @@ extension FixedWidthInteger where Self: MockUsable {
 
 }
 
-extension Int: MockUsable { public static let any = 42 }
-extension Int64: MockUsable { public static let any = 42 }
-extension UInt: MockUsable { public static let any = 42 }
-extension UInt64: MockUsable { public static let any = 42 }
+extension Int: MockUsable {
+    public static let any = 42
+    
+    public static var anyValue: MockUsable {
+        return Int.any
+    }
+}
+extension Int64: MockUsable {
+    public static let any = 42 as Int64
+    
+    public static var anyValue: MockUsable {
+        return Int64.any
+    }
+}
+extension UInt: MockUsable {
+    public static let any = 42 as UInt
+    
+    public static var anyValue: MockUsable {
+        return UInt.any
+    }
+}
+extension UInt64: MockUsable {
+    public static let any = 42 as UInt64
+    
+    public static var anyValue: MockUsable {
+        return UInt64.any
+    }
+}

--- a/Sources/InstantMock/MockUsable/Int+MockUsable.swift
+++ b/Sources/InstantMock/MockUsable/Int+MockUsable.swift
@@ -8,17 +8,20 @@
 
 
 /** Extension for making `Int` easily usage in mocks */
-extension Int: MockUsable {
-
-    public static let any = 42
+extension FixedWidthInteger where Self: MockUsable {
 
     public static var anyValue: MockUsable {
         return Int.any
     }
 
     public func equal(to value: MockUsable?) -> Bool {
-        guard let intValue = value as? Int else { return false }
+        guard let intValue = value as? Self else { return false }
         return self == intValue
     }
 
 }
+
+extension Int: MockUsable { public static let any = 42 }
+extension Int64: MockUsable { public static let any = 42 }
+extension UInt: MockUsable { public static let any = 42 }
+extension UInt64: MockUsable { public static let any = 42 }

--- a/Tests/InstantMockTests/Integration Tests/TypesMockTests.swift
+++ b/Tests/InstantMockTests/Integration Tests/TypesMockTests.swift
@@ -40,7 +40,19 @@ final class TypesMock: Mock, TypesProtocol {
     func integer(_ int: Int) -> Int {
         return super.call(int)!
     }
+    
+    func integer64(_ int: Int64) -> Int64 {
+        return super.call(int)!
+    }
+    
+    func unsignedInteger64(_ int: UInt64) -> UInt64 {
+        return super.call(int)!
+    }
 
+    func float(_ float: Float) -> Float {
+        return super.call(float)!
+    }
+    
     func double(_ double: Double) -> Double {
         return super.call(double)!
     }
@@ -90,6 +102,9 @@ final class TypesMockTests: XCTestCase {
         ("testEmpty", testEmpty),
         ("testBool", testBool),
         ("testInt", testInt),
+        ("testInt64", testInt64),
+        ("testUnsignedInt64", testUnsignedInt64),
+        ("testFloat", testFloat),
         ("testDouble", testDouble),
         ("testString", testString),
         ("testString_nil", testString_nil),
@@ -138,7 +153,46 @@ final class TypesMockTests: XCTestCase {
         XCTAssertTrue(self.assertionMock.succeeded)
     }
 
+    
+    func testInt64() {
+        self.mock.expect().call(self.mock.integer64(Arg.any()))
 
+        self.mock.verify()
+        XCTAssertFalse(self.assertionMock.succeeded)
+
+        _ = self.mock.integer64(12)
+
+        self.mock.verify()
+        XCTAssertTrue(self.assertionMock.succeeded)
+    }
+    
+    
+    func testUnsignedInt64() {
+        self.mock.expect().call(self.mock.unsignedInteger64(Arg.any()))
+
+        self.mock.verify()
+        XCTAssertFalse(self.assertionMock.succeeded)
+
+        _ = self.mock.unsignedInteger64(12)
+
+        self.mock.verify()
+        XCTAssertTrue(self.assertionMock.succeeded)
+    }
+
+    
+    func testFloat() {
+        self.mock.expect().call(self.mock.float(Arg.any()))
+
+        self.mock.verify()
+        XCTAssertFalse(self.assertionMock.succeeded)
+
+        _ = self.mock.float(12.0)
+
+        self.mock.verify()
+        XCTAssertTrue(self.assertionMock.succeeded)
+    }
+    
+    
     func testDouble() {
         self.mock.expect().call(self.mock.double(Arg.any()))
 

--- a/Tests/InstantMockTests/Integration Tests/TypesMockTests.swift
+++ b/Tests/InstantMockTests/Integration Tests/TypesMockTests.swift
@@ -45,6 +45,10 @@ final class TypesMock: Mock, TypesProtocol {
         return super.call(int)!
     }
     
+    func unsignedInteger(_ int: UInt) -> UInt {
+        return super.call(int)!
+    }
+    
     func unsignedInteger64(_ int: UInt64) -> UInt64 {
         return super.call(int)!
     }
@@ -103,6 +107,7 @@ final class TypesMockTests: XCTestCase {
         ("testBool", testBool),
         ("testInt", testInt),
         ("testInt64", testInt64),
+        ("testUnsignedInt", testUnsignedInt),
         ("testUnsignedInt64", testUnsignedInt64),
         ("testFloat", testFloat),
         ("testDouble", testDouble),
@@ -166,6 +171,17 @@ final class TypesMockTests: XCTestCase {
         XCTAssertTrue(self.assertionMock.succeeded)
     }
     
+    func testUnsignedInt() {
+        self.mock.expect().call(self.mock.unsignedInteger(Arg.any()))
+
+        self.mock.verify()
+        XCTAssertFalse(self.assertionMock.succeeded)
+
+        _ = self.mock.unsignedInteger(12)
+
+        self.mock.verify()
+        XCTAssertTrue(self.assertionMock.succeeded)
+    }
     
     func testUnsignedInt64() {
         self.mock.expect().call(self.mock.unsignedInteger64(Arg.any()))

--- a/Tests/InstantMockTests/Unit Tests/MockUsable/FloatMockUsableTests.swift
+++ b/Tests/InstantMockTests/Unit Tests/MockUsable/FloatMockUsableTests.swift
@@ -1,0 +1,48 @@
+//
+//  FloatMockUsableTests.swift
+//  InstantMock
+//
+//  Created by Patrick on 06/05/2017.
+//  Copyright 2017 pirishd. All rights reserved.
+//
+
+import XCTest
+@testable import InstantMock
+
+
+final class FloatMockUsableTests: XCTestCase {
+
+
+    static var allTests = [
+        ("testEqual_toNil", testEqual_toNil),
+        ("testEqual_toWrongType", testEqual_toWrongType),
+        ("testEqual_toWrongValue", testEqual_toWrongValue),
+        ("testEqual_toExpectedValue", testEqual_toExpectedValue),
+    ]
+
+
+    func testEqual_toNil() {
+        let ret = (12.0 as Float).equal(to: nil)
+        XCTAssertFalse(ret)
+    }
+
+
+    func testEqual_toWrongType() {
+        let ret = (12.0 as Float).equal(to: 12)
+        XCTAssertFalse(ret)
+    }
+
+
+    func testEqual_toWrongValue() {
+        let ret = (12.0 as Float).equal(to: 13.0 as Float)
+        XCTAssertFalse(ret)
+    }
+
+
+    func testEqual_toExpectedValue() {
+        let ret = (12.0 as Float).equal(to: 12.0 as Float)
+        XCTAssertTrue(ret)
+    }
+
+
+}

--- a/Tests/InstantMockTests/Unit Tests/MockUsable/FloatMockUsableTests.swift
+++ b/Tests/InstantMockTests/Unit Tests/MockUsable/FloatMockUsableTests.swift
@@ -2,7 +2,7 @@
 //  FloatMockUsableTests.swift
 //  InstantMock
 //
-//  Created by Patrick on 06/05/2017.
+//  Created by Arnaud Barisain-Monrose on 21/04/2020.
 //  Copyright 2017 pirishd. All rights reserved.
 //
 

--- a/Tests/InstantMockTests/Unit Tests/MockUsable/IntMockUsableTests.swift
+++ b/Tests/InstantMockTests/Unit Tests/MockUsable/IntMockUsableTests.swift
@@ -18,6 +18,8 @@ final class IntMockUsableTests: XCTestCase {
         ("testEqual_toWrongType", testEqual_toWrongType),
         ("testEqual_toWrongValue", testEqual_toWrongValue),
         ("testEqual_toExpectedValue", testEqual_toExpectedValue),
+        ("testEqual_toExpectedValue_int64", testEqual_toExpectedValue_int64),
+        ("testEqual_toExpectedValue_uint64", testEqual_toExpectedValue_uint64),
     ]
 
 
@@ -43,6 +45,15 @@ final class IntMockUsableTests: XCTestCase {
         let ret = 12.equal(to: 12)
         XCTAssertTrue(ret)
     }
+    
+    func testEqual_toExpectedValue_int64() {
+        let ret = Int64.max.equal(to: Int64.max)
+        XCTAssertTrue(ret)
+    }
 
+    func testEqual_toExpectedValue_uint64() {
+        let ret = UInt64.max.equal(to: UInt64.max)
+        XCTAssertTrue(ret)
+    }
 
 }

--- a/Tests/InstantMockTests/Unit Tests/Verifications/VerifierTests.swift
+++ b/Tests/InstantMockTests/Unit Tests/Verifications/VerifierTests.swift
@@ -27,6 +27,9 @@ final class VerifierTests: XCTestCase {
         ("testEqual_secondNil", testEqual_secondNil),
         ("testEqual_strings", testEqual_strings),
         ("testEqual_stringsWithDifferentValues", testEqual_stringsWithDifferentValues),
+        ("testEqual_floats", testEqual_floats),
+        ("testEqual_int64s", testEqual_int64s),
+        ("testEqual_uint64s", testEqual_uint64s),
         ("testEqual_references", testEqual_references),
         ("testMatch_differentReferences", testMatch_differentReferences),
         ("testMatch_closure_failure", testMatch_closure_failure),
@@ -62,12 +65,25 @@ final class VerifierTests: XCTestCase {
         XCTAssertTrue(ret)
     }
 
-
     func testEqual_stringsWithDifferentValues() {
         let ret = self.verifier.equal("something", to: "something else")
         XCTAssertFalse(ret)
     }
+    
+    func testEqual_floats() {
+        let ret = self.verifier.equal(1.234 as Float, to: 1.234 as Float)
+        XCTAssertTrue(ret)
+    }
+    
+    func testEqual_int64s() {
+        let ret = self.verifier.equal(Int64.max, to: Int64.max)
+        XCTAssertTrue(ret)
+    }
 
+    func testEqual_uint64s() {
+        let ret = self.verifier.equal(UInt64.max, to: UInt64.max)
+        XCTAssertTrue(ret)
+    }
 
     func testEqual_references() {
         let instance = DummyArgsMatcher()


### PR DESCRIPTION
Hello,

Thanks for your work on the library! It has been very useful to easily add expectations in my Swift project.

I have noticed that my functions explicitly handling Int64 values were failing when I used numbers too big for an Int.

```swift
func testEqual_int64s() {
        let ret = self.verifier.equal(Int64.max, to: Int64.max)
        XCTAssertTrue(ret)
}
```

After investigating, it turns out that when a value doesn't fit into an Int, the library can't compare them.
I tweaked Int+MockUsable to handle all FixedWidthIntegers, and then explicitly added support for UInt64 and Int64. I kept Int and UInt, as it's better not to force the library to use 64bit words if not necessary, even if performance isn't that important in this kind of testing library.

Further testing showed that Floats didn't work out of the box either, so I also added support for that.

Side note: It was quite hard to debug, maybe the library could use some sort of debug mode to understand why an argument doesn't match (the debugger reported Int64 on both the expectation and actual value, which was confusion).